### PR TITLE
Feat ot112 chat 16 personal configuration

### DIFF
--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -15,7 +15,7 @@ module Api
         )
         @messages.each do |chat|
           chat.each do |message|
-            if @user.settings
+            if @user.settings.include? 'true'
               @message = message
               @message.detail = settings
             end

--- a/app/controllers/api/v1/messages_controller.rb
+++ b/app/controllers/api/v1/messages_controller.rb
@@ -13,6 +13,14 @@ module Api
           items: params[:items] || 10,
           page: params[:page] || 1
         )
+        @messages.each do |chat|
+          chat.each do |message|
+            if @user.settings
+              @message = message
+              @message.detail = settings
+            end
+          end
+        end
         @messages.order(created_at: :desc)
         render json: MessageSerializer.new(@messages).serializable_hash.to_json
       end
@@ -28,6 +36,8 @@ module Api
           @conversation.users << @current_user
           @message = @conversation.messages.build(message_params)
           @message.user = @current_user
+          @message.detail = settings if @user.settings.include? 'true'
+
           if @message.save
             render json: MessageSerializer.new(@message), status: :created
           else
@@ -44,6 +54,17 @@ module Api
 
       def max_users?
         Conversation.where(id: params[:conversation_id]).count == 2
+      end
+
+      def settings
+        settings = eval(@current_user.settings)
+        if settings['upcase'] == true
+          @message.detail = @message.detail.upcase
+        elsif settings['downcase'] == true
+          @message.detail = @message.detail.downcase
+        elsif settings['normalize'] == true
+          @message.detail = ActiveSupport::Inflector.transliterate(@message.detail)
+        end
       end
 
       def message_params

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -63,7 +63,11 @@ module Api
       end
 
       def user_params
+<<<<<<< HEAD
         params.require(:user).permit(:name, :password, :email)
+=======
+        params.permit(:name, :password, :email, :id, :settings)
+>>>>>>> 163291c (feat-OT112CHAT16-add-personal-configuration)
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -9,6 +9,7 @@
 #  is_admin        :boolean          default(FALSE)
 #  name            :string           not null
 #  password_digest :string
+#  settings        :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -9,6 +9,7 @@
 #  is_admin        :boolean          default(FALSE)
 #  name            :string           not null
 #  password_digest :string
+#  settings        :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #

--- a/db/migrate/20220116061429_add_settings_to_users.rb
+++ b/db/migrate/20220116061429_add_settings_to_users.rb
@@ -1,0 +1,5 @@
+class AddSettingsToUsers < ActiveRecord::Migration[6.1]
+  def change
+    add_column :users, :settings, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -52,6 +52,7 @@ ActiveRecord::Schema.define(version: 2022_01_24_000711) do
     t.boolean "is_admin", default: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.string "settings"
     t.index ["email"], name: "index_users_on_email", unique: true
   end
 

--- a/spec/factories/conversations.rb
+++ b/spec/factories/conversations.rb
@@ -1,5 +1,19 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: conversations
+#
+#  id         :bigint           not null, primary key
+#  deleted_at :datetime
+#  state      :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+# Indexes
+#
+#  index_conversations_on_deleted_at  (deleted_at)
+#
 FactoryBot.define do
   factory :conversation do
     user1_id { 1 }

--- a/spec/factories/messages.rb
+++ b/spec/factories/messages.rb
@@ -1,5 +1,29 @@
 # frozen_string_literal: true
 
+# == Schema Information
+#
+# Table name: messages
+#
+#  id              :bigint           not null, primary key
+#  deleted_at      :datetime
+#  detail          :string           not null
+#  modified        :boolean          default(FALSE)
+#  created_at      :datetime         not null
+#  updated_at      :datetime         not null
+#  conversation_id :bigint           not null
+#  user_id         :bigint           not null
+#
+# Indexes
+#
+#  index_messages_on_conversation_id  (conversation_id)
+#  index_messages_on_deleted_at       (deleted_at)
+#  index_messages_on_user_id          (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (conversation_id => conversations.id)
+#  fk_rails_...  (user_id => users.id)
+#
 FactoryBot.define do
   factory :message do
     user_id { 1 }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -9,6 +9,7 @@
 #  is_admin        :boolean          default(FALSE)
 #  name            :string           not null
 #  password_digest :string
+#  settings        :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -9,6 +9,7 @@
 #  is_admin        :boolean          default(FALSE)
 #  name            :string           not null
 #  password_digest :string
+#  settings        :string
 #  created_at      :datetime         not null
 #  updated_at      :datetime         not null
 #


### PR DESCRIPTION
- Added settings column to user model.
- Added route for create.
- Implemented a method 'settings' to modify the message according to personal configuration of current user.
- Added create endpoint.
- Index endpoint were modified to fit the requirements.

This PR still needs some work, and should be modified when the pendings tickets are merged. Still pending:

- deleted_at columns column to tables (acts_as_paranoid implementation)
- Conversations controller, relations and methods.
- create endpoint ticket for messages.

I am open to alternatives about using eval to evaluate string settings as a hash. Checked other options with no good results.